### PR TITLE
Add store.size.total metric

### DIFF
--- a/neo4j/bin/generate-metadata-content
+++ b/neo4j/bin/generate-metadata-content
@@ -290,6 +290,9 @@ def _get_metrics_info():
         'ids_in_use_relationship_type': Info(
             description='The total number of different relationship types stored in the database.',
         ),
+        'store_size_total': Info(
+            description='The total size of the database and transaction logs'
+        ),
         'store_size_database': Info(
             description='The on disk size of the database.',
         ),

--- a/neo4j/datadog_checks/neo4j/neo4j.py
+++ b/neo4j/datadog_checks/neo4j/neo4j.py
@@ -162,6 +162,7 @@ class Neo4jCheck(PrometheusCheck):
             'ids_in_use_property': 'ids_in_use.property',
             'ids_in_use_relationship': 'ids_in_use.relationship',
             'ids_in_use_relationship_type': 'ids_in_use.relationship_type',
+            'store_size_total': 'store.size.total',
             'store_size_database': 'store.size.database',
             #
             # database transaction log metrics

--- a/neo4j/metadata.csv
+++ b/neo4j/metadata.csv
@@ -65,6 +65,7 @@ neo4j.ids_in_use.node,gauge,,,,The total number of nodes stored in the database.
 neo4j.ids_in_use.property,gauge,,,,The total number of different property names used in the database.,0,neo4j,ids in use property
 neo4j.ids_in_use.relationship,gauge,,,,The total number of relationships stored in the database.,0,neo4j,ids in use relationship
 neo4j.ids_in_use.relationship_type,gauge,,,,The total number of different relationship types stored in the database.,0,neo4j,ids in use relationship type
+neo4j.store.size.total,gauge,,,,The total size of the database and transaction logs.,0,neo4j,store size total
 neo4j.store.size.database,gauge,,,,The on disk size of the database.,0,neo4j,store size database
 neo4j.log.appended_bytes,gauge,,,,The total number of bytes appended to transaction log.,0,neo4j,log appended bytes
 neo4j.log.rotation_events,gauge,,,,The total number of transaction log rotations executed so far.,0,neo4j,log rotation events


### PR DESCRIPTION
### What does this PR do?

Adds metric `neo4j.store.size.total`.

### Motivation

We use it for store size charts in 3.x, and without it the charts are incorrect for 4.x.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)


