### PR TITLE
Add support for metrics.namespaced.enabled in neo4j

### DIFF
--- a/neo4j/tests/conftest.py
+++ b/neo4j/tests/conftest.py
@@ -24,10 +24,10 @@ def ensure_prometheus_endpoint_is_accessable():
 @pytest.fixture(scope='session')
 def dd_environment():
     instance = INSTANCE
-    envs = {'NEO4J_VERSION': os.environ['NEO4J_VERSION']}
+    image = os.environ.get("NEO4J_IMAGE", f"neo4j:{os.environ['NEO4J_VERSION']}-enterprise")
     with docker_run(
         os.path.join(DOCKER_DIR, 'docker-compose.yaml'),
-        env_vars=envs,
+        env_vars={'NEO4J_IMAGE': image},
         log_patterns=['Remote interface available at'],
         conditions=[WaitFor(ensure_prometheus_endpoint_is_accessable)],
     ):

--- a/neo4j/tests/docker/docker-compose.yaml
+++ b/neo4j/tests/docker/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   neo4j:
-    image: neo4j:${NEO4J_VERSION}-enterprise
+    image: ${NEO4J_IMAGE}
     ports:
       - 2004:2004
     environment:


### PR DESCRIPTION
This solves an ambiguity problem with the default
metrics naming scheme.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
