### PR TITLE
Fix metrics reporting

### DIFF
--- a/neo4j/datadog_checks/neo4j/neo4j.py
+++ b/neo4j/datadog_checks/neo4j/neo4j.py
@@ -39,7 +39,9 @@ class Neo4jCheck(PrometheusCheck):
         # Finding this dynamically lets users roll out this feature without interrupting their metrics,
         # as well as monitoring database fleets with mixed values for this setting.
         is_namespaced = True
+        new_metrics = []
         for metric in metrics:
+            new_metrics.append(metric)
             if metric.name.startswith("neo4j_dbms_") or metric.name.startswith("neo4j_database_"):
                 continue
             is_namespaced = False

--- a/neo4j/datadog_checks/neo4j/neo4j.py
+++ b/neo4j/datadog_checks/neo4j/neo4j.py
@@ -39,9 +39,10 @@ class Neo4jCheck(PrometheusCheck):
         # Finding this dynamically lets users roll out this feature without interrupting their metrics,
         # as well as monitoring database fleets with mixed values for this setting.
         is_namespaced = True
-        new_metrics = []
-        for metric in metrics:
-            new_metrics.append(metric)
+        # convert the generator to a normal list
+        new_metrics = list(metrics)
+
+        for metric in new_metrics:
             if metric.name.startswith("neo4j_dbms_") or metric.name.startswith("neo4j_database_"):
                 continue
             is_namespaced = False

--- a/neo4j/datadog_checks/neo4j/neo4j.py
+++ b/neo4j/datadog_checks/neo4j/neo4j.py
@@ -48,9 +48,9 @@ class Neo4jCheck(PrometheusCheck):
             break
 
         if is_namespaced:
-            self._check_namespaced_metrics(metrics, config)
+            self._check_namespaced_metrics(new_metrics, config)
         else:
-            self._check_legacy_metrics(metrics, config)
+            self._check_legacy_metrics(new_metrics, config)
 
     def _check_namespaced_metrics(self, metrics, config):
         for metric in metrics:


### PR DESCRIPTION
### What does this PR do?

Introduced in #8, we added support for name spaced metrics. This required us to iterate over the list of metrics once before passing it to the actual metrics handling. Since the metrics object it not a real array, but a `generator object`, this first iteration will empty the generator, so when actually wanting to process the metrics, there is non coming out of the generator.

In order to support this name spaced metrics, we just copy the elements coming out of the generator when we first iterate and pass this over to the metrics handling 🤷 

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
