### PR TITLE
Add transaction size metrics

### DIFF
--- a/neo4j/datadog_checks/neo4j/neo4j.py
+++ b/neo4j/datadog_checks/neo4j/neo4j.py
@@ -238,6 +238,8 @@ class Neo4jCheck(PrometheusCheck):
             'transaction_terminated_read_total': 'transaction.terminated_read',
             'transaction_terminated_total': 'transaction.terminated',
             'transaction_terminated_write_total': 'transaction.terminated_write',
+            'transaction_tx_size_heap': 'transaction.tx_size_heap',
+            'transaction_tx_size_native': 'transaction.tx_size_native',
             #
             # JVM GC metrics
             'vm_gc_count_g1_old_generation_total': 'vm.gc.count.g1_old_generation',


### PR DESCRIPTION
### What does this PR do?

This PR adds new transaction size metrics: 
* transaction.tx_size_heap - transactions' size on heap in bytes, histogram 
* transaction.tx_size_native - transactions' size in native memory in bytes, histogram.

### Motivation

Better tracking of transactions' heap usage.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
