### PR TITLE
Add causal_clustering_core_applied_index

### DIFF
--- a/neo4j/datadog_checks/neo4j/neo4j.py
+++ b/neo4j/datadog_checks/neo4j/neo4j.py
@@ -139,6 +139,7 @@ class Neo4jCheck(PrometheusCheck):
             # causal clustering metrics
             'causal_clustering_catchup_tx_pull_requests_received_total': 'causal_clustering.catchup_tx_pull_requests_received',  # noqa: E501
             'causal_clustering_core_append_index': 'causal_clustering.core.append_index',
+            'causal_clustering_core_applied_index': 'causal_clustering.core.applied_index',
             'causal_clustering_core_commit_index': 'causal_clustering.core.commit_index',
             'causal_clustering_core_discovery_cluster_converged': 'causal_clustering.core.discovery.cluster.converged',  # noqa: E501
             'causal_clustering_core_discovery_cluster_members': 'causal_clustering.core.discovery.cluster.members',  # noqa: E501


### PR DESCRIPTION
### What does this PR do?

Allow lists an extra metric when debugging raft-log rotation issues. We already have two metrics in place:
causal_clustering_core_append_index
causal_clustering_core_commit_index

This PR adds the third one
causal_clustering_core_applied_index

### Motivation

Insufficient data around to troubleshoot raft-log rotation issues.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Git history is clean

