### PR TITLE
Bugfix: recognise Neo4j v5 in `_get_config()`

### DIFF
--- a/neo4j/datadog_checks/neo4j/neo4j.py
+++ b/neo4j/datadog_checks/neo4j/neo4j.py
@@ -99,7 +99,7 @@ class Neo4jCheck(PrometheusCheck):
         exclude_labels = self._get_value(instance=instance, key='exclude_labels', required=False, default_value=[])
         instance_tags = self._get_value(instance=instance, key='tags', required=False, default_value=[])
 
-        if neo4j_version not in ["3.5", "4.0"]:
+        if neo4j_version not in ["3.5", "4.0", "5.0"]:
             raise ConfigurationError('neo4j_version "{}" is not a valid value'.format(neo4j_version))
 
         return Config(


### PR DESCRIPTION
### What does this PR do?

Enables the component to collect metrics from Neo4j version 5.

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

