### PR TITLE
Process metrics should use send_monotonic_counter=True as the default

### DIFF
--- a/neo4j/datadog_checks/neo4j/neo4j.py
+++ b/neo4j/datadog_checks/neo4j/neo4j.py
@@ -68,7 +68,7 @@ class Neo4jCheck(PrometheusCheck):
             tags = ['db_name:{}'.format(db_name)]
             if config.instance_tags:
                 tags.extend(config.instance_tags.copy())
-            self.process_metric(message=metric, custom_tags=tags)
+            self.process_metric(message=metric, custom_tags=tags, send_monotonic_counter=True)
 
     def _check_legacy_metrics(self, metrics, config):
         for metric in metrics:
@@ -83,7 +83,7 @@ class Neo4jCheck(PrometheusCheck):
             tags = ['db_name:{}'.format(db_name)]
             if config.instance_tags:
                 tags.extend(config.instance_tags.copy())
-            self.process_metric(message=metric, custom_tags=tags)
+            self.process_metric(message=metric, custom_tags=tags, send_monotonic_counter=True)
 
     def _get_db_for_metric(self, dbs, metric_name):
         for db in dbs:


### PR DESCRIPTION
### What does this PR do?

Makes Neo4j prometheus metrics (counters) be sent to datadog as monotonic_counter which is the default as seen below.

https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/checks/prometheus/base_check.py#L109

For some reason parts of the code have a different default:

https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py#L509

### Motivation

What inspired you to submit this pull request?

<img width="883" alt="Screenshot 2022-04-22 at 13 29 36" src="https://user-images.githubusercontent.com/11268775/164714842-0756cbf7-30c9-437a-8e83-84f3631a9036.png">

Metric is appearing as a gauge in datadog

But prometheus has them as counters:

```
# TYPE neo4j_dbms_bolt_connections_opened_total counter
# TYPE neo4j_dbms_bolt_connections_closed_total counter
```

