### PR TITLE
Add mapping for GDS metric

### DIFF
--- a/neo4j/datadog_checks/neo4j/neo4j.py
+++ b/neo4j/datadog_checks/neo4j/neo4j.py
@@ -356,5 +356,6 @@ class Neo4jCheck(PrometheusCheck):
             'db_query_execution_latency_millis': 'db.query.execution.latency.millis',
 
             # GDS metrics
-            'gds_graphs_created': 'gds.graphs_created',
+            'gds.neo4j_graphs_created': 'gds.neo4j.graphs_created',
+            'gds.system_graphs_created': 'gds.system.graphs_created',
         }

--- a/neo4j/datadog_checks/neo4j/neo4j.py
+++ b/neo4j/datadog_checks/neo4j/neo4j.py
@@ -354,4 +354,7 @@ class Neo4jCheck(PrometheusCheck):
             'db_query_execution_success_total': 'db.query.execution.success.total',
             'db_query_execution_failure_total': 'db.query.execution.failure.total',
             'db_query_execution_latency_millis': 'db.query.execution.latency.millis',
+
+            # GDS metrics
+            'gds_graphs_create': 'gds.graphs_created',
         }

--- a/neo4j/datadog_checks/neo4j/neo4j.py
+++ b/neo4j/datadog_checks/neo4j/neo4j.py
@@ -356,5 +356,5 @@ class Neo4jCheck(PrometheusCheck):
             'db_query_execution_latency_millis': 'db.query.execution.latency.millis',
 
             # GDS metrics
-            'gds_graphs_create': 'gds.graphs_created',
+            'gds_graphs_created': 'gds.graphs_created',
         }


### PR DESCRIPTION
### What does this PR do?
Adding the first GDS metric which will be exposed starting with `2.3.4+17` (https://github.com/neo-technology/neo4j-cloud/pull/15306 PR for the GDS release)

### Motivation

We finally want to leverage metrics for GDS :)

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

