### PR TITLE
Report Prometheus counters as the correct type

### DIFF
--- a/neo4j/datadog_checks/neo4j/neo4j.py
+++ b/neo4j/datadog_checks/neo4j/neo4j.py
@@ -106,7 +106,7 @@ class Neo4jCheck(PrometheusCheck):
             if meta_map and db_name in meta_map:
                 tags.extend(meta_map[db_name])
 
-            self.process_metric(message=metric, custom_tags=tags, ignore_unmapped=True)
+            self.process_metric(message=metric, custom_tags=tags, ignore_unmapped=True, send_monotonic_counter=True)
 
     def _check_legacy_metrics(self, metrics, config, meta_map):
         for metric in metrics:
@@ -128,7 +128,7 @@ class Neo4jCheck(PrometheusCheck):
             if meta_map and db_name in meta_map:
                 tags.extend(meta_map[db_name])
 
-            self.process_metric(message=metric, custom_tags=tags, ignore_unmapped=True)
+            self.process_metric(message=metric, custom_tags=tags, ignore_unmapped=True, send_monotonic_counter=True)
 
     def _get_db_for_metric(self, dbs, metric_name):
         for db in dbs:


### PR DESCRIPTION
### What does this PR do?

Opposed to the [documentation](https://docs.datadoghq.com/integrations/prometheus/#configuration), Prometheus Counters get translated to Datadog Gauge by default.
[Code]https://github.com/DataDog/integrations-core/blob/a31b426704b6b896725c97bcdf663644414b0251/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py#L509) showing `False` is actually the default for `send_monotonic_counter`.

However, it also seems like we use the legacy Prometheus Integration in datadog?


### Motivation

What inspired you to submit this pull request?

The datadog plots were hard to read with counters getting resetted. (see f.i. https://neo4j-aura.datadoghq.com/metric/explorer?start=1695374800748&end=1695378400748&paused=false#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKGABuMMgicDgALABWAHQwUBpOMNoY8owdmUaecFBOCDgIGGjAAFQ8IDwAulSu7niYoeErqmsYMaXx80sgGnJoOaDyk4gIOUk4ME6Z6xoQmYloonCjCrfpH1DvT5OehMZQiNweNDzfgQeyYLDfRTKD61Q48PjHeQfBAAYSkwhgKBEazQPCAA)

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
