### PR TITLE
Enable GDS metrics that do not come from drop wizard

### DIFF
--- a/neo4j/datadog_checks/neo4j/neo4j.py
+++ b/neo4j/datadog_checks/neo4j/neo4j.py
@@ -52,7 +52,7 @@ class Neo4jCheck(PrometheusCheck):
                 metadata_info_metric = metric
                 continue
 
-            if metric.name.startswith("neo4j_dbms_") or metric.name.startswith("neo4j_database_"):
+            if metric.name.startswith("neo4j_dbms_") or metric.name.startswith("neo4j_database_") or metric.name.startswith("gds"):
                 is_namespaced = True
 
             if metadata_info_metric is not None:
@@ -98,8 +98,14 @@ class Neo4jCheck(PrometheusCheck):
                 # Exclude databases not in neo4j_dbs, if that config is set
                 if config.neo4j_dbs and db_name not in config.neo4j_dbs:
                     continue
+            elif metric.name.startswith("gds"):
+                db_name = ""
 
-            tags = ['db_name:{}'.format(db_name)]
+            tags = []
+
+            if db_name: 
+                tags.extend(['db_name:{}'.format(db_name)])
+
             if config.instance_tags:
                 tags.extend(config.instance_tags.copy())
 

--- a/neo4j/datadog_checks/neo4j/neo4j.py
+++ b/neo4j/datadog_checks/neo4j/neo4j.py
@@ -89,6 +89,8 @@ class Neo4jCheck(PrometheusCheck):
             if metric.name == "metadata_info":
                 continue
 
+            send_monotonic_counter=False
+
             if metric.name.startswith("neo4j_dbms_"):
                 db_name = GLOBAL_DB_NAME
                 metric.name = metric.name.replace("neo4j_dbms_", "", 1)
@@ -100,6 +102,7 @@ class Neo4jCheck(PrometheusCheck):
                     continue
             elif metric.name.startswith("gds"):
                 db_name = ""
+                send_monotonic_counter=True
 
             tags = []
 
@@ -112,7 +115,7 @@ class Neo4jCheck(PrometheusCheck):
             if meta_map and db_name in meta_map:
                 tags.extend(meta_map[db_name])
 
-            self.process_metric(message=metric, custom_tags=tags, ignore_unmapped=True)
+            self.process_metric(message=metric, custom_tags=tags, ignore_unmapped=True, send_monotonic_counter=send_monotonic_counter)
 
     def _check_legacy_metrics(self, metrics, config, meta_map):
         for metric in metrics:


### PR DESCRIPTION
### What does this PR do?

This PR enables GDS metrics (those starting with `gds`) to be parsed by the datadog integration.

### Motivation

To enable GDS metric published without drop wizard

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?

- [ ] Need to check that this is backwards compatible
- [ ] Can we add the monotonic counter stuff in here?
