### PR TITLE
Send deprecation notification metrics as counter

### DIFF
--- a/neo4j/datadog_checks/neo4j/neo4j.py
+++ b/neo4j/datadog_checks/neo4j/neo4j.py
@@ -105,7 +105,8 @@ class Neo4jCheck(PrometheusCheck):
                 db_name = ""
                 send_monotonic_counter = True
                 send_buckets = True
-            elif metric.name.endswith("_total"):
+
+            if "cypher_internal_notification_count" in metric.name:
                 send_monotonic_counter = True
 
             tags = []
@@ -118,6 +119,8 @@ class Neo4jCheck(PrometheusCheck):
 
             if meta_map and db_name in meta_map:
                 tags.extend(meta_map[db_name])
+
+            print('received namespaced metric' + metric.name + ' monotonic ' + str(send_monotonic_counter))
 
             self.process_metric(
                 message=metric, custom_tags=tags,

--- a/neo4j/datadog_checks/neo4j/neo4j.py
+++ b/neo4j/datadog_checks/neo4j/neo4j.py
@@ -120,8 +120,6 @@ class Neo4jCheck(PrometheusCheck):
             if meta_map and db_name in meta_map:
                 tags.extend(meta_map[db_name])
 
-            print('received namespaced metric' + metric.name + ' monotonic ' + str(send_monotonic_counter))
-
             self.process_metric(
                 message=metric, custom_tags=tags,
                 ignore_unmapped=True,

--- a/neo4j/datadog_checks/neo4j/neo4j.py
+++ b/neo4j/datadog_checks/neo4j/neo4j.py
@@ -105,6 +105,8 @@ class Neo4jCheck(PrometheusCheck):
                 db_name = ""
                 send_monotonic_counter = True
                 send_buckets = True
+            elif metric.name.endswith("_total"):
+                send_monotonic_counter = True
 
             tags = []
 


### PR DESCRIPTION
### What does this PR do?

Sends all Neo4j metrics that include `cypher_internal_notification_count` in their names as `count` type (opposed to the default `gauge` type).

### Motivation

To make sense of deprecation notification metrics, they need to be saved as `count` and not `gauge`.

If they are, Datadog `cumsum()` function can be applied as follows to get "pod restart safe" visualizations:

![image](https://github.com/neo-technology/integrations-extras/assets/2542670/2d4c574c-9c24-46f6-b01c-86c508e71485)

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

[Trello card](https://trello.com/c/O89S53a5/2253-add-new-metrics-to-be-scraped-by-datadog?filter=deprecation+metrics)

Tested on my devenv by doing the following:

```
diff --git a/build/containers/datadog-agent/Dockerfile b/build/containers/datadog-agent/Dockerfile
index 502d5cff66..20da230797 100644
--- a/build/containers/datadog-agent/Dockerfile
+++ b/build/containers/datadog-agent/Dockerfile
@@ -2,8 +2,8 @@ ARG PYTHON_VERSION=notag
 ARG DD_AGENT_IMAGE_TAG=notag
 FROM python:$PYTHON_VERSION AS wheel_builder
 
-ARG REPO_ORG=norepo
-ARG REPO_BRANCH=nobranch
+ARG REPO_ORG=alexnb
+ARG REPO_BRANCH=send-deprecation-notification-metrics-as-counter
 
 # Versions newer than 6.1.0 are not supported in Python version 3.9
 # Error is: TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
diff --git a/build/datadog-agent-image-id b/build/datadog-agent-image-id
index a0bc374519..de26daf59a 100644
--- a/build/datadog-agent-image-id
+++ b/build/datadog-agent-image-id
@@ -1 +1 @@
-eu.gcr.io/neo4j-cloud-commons/datadog-agent:5d226c9f-526c-4487-afe1-2f20fb80201a
\ No newline at end of file
+eu.gcr.io/neo4j-cloud-commons/datadog-agent:0f401b92-9abc-445f-af46-285f8c6c2238
\ No newline at end of file
diff --git a/components/datadog-agent/devenv b/components/datadog-agent/devenv
index f60f496dd5..ee87e49ba0 100644
--- a/components/datadog-agent/devenv
+++ b/components/datadog-agent/devenv
@@ -29,10 +29,10 @@ export DD_CLUSTER_AGENT_VERSION="${DD_AGENT_VERSION}"
 export DD_CRD_CHART_VERSION="1.2.0"
 
 # can be set to either 'DataDog' (if latest changes are merged to upstream) or 'neo-technology' (if latest changes are not merged to upstream).
-export DD_EXTRAS_REPO_ORG="neo-technology"
+export DD_EXTRAS_REPO_ORG="alexnb"
 # which branch that should be checked out, this should be 'master' except when you are making changes to neo4j enterprise integration and testing them
 # out before merging the changes to master.
-export DD_EXTRAS_REPO_BRANCH="master"
+export DD_EXTRAS_REPO_BRANCH="send-deprecation-notification-metrics-as-counter"
 
 : "${DD_DEV_ENVS_API_KEY:=$(secrets-getter DD_DEV_ENVS_API_KEY)}"
 export DD_DEV_ENVS_API_KEY
```

```
make clean-components-datadog-agent && make ensure-publish-datadog-agent-image-is-rebuild && make tmp/datadog-agent-image-id && make build/datadog-agent-image-id && make c/datadog-agent && ENVIRONMENT=devsascha environments components update datadog-agent
```