### PR TITLE
Repair Datadog integration_extras (Aura incident 1980)

### DIFF
--- a/neo4j/datadog_checks/neo4j/neo4j.py
+++ b/neo4j/datadog_checks/neo4j/neo4j.py
@@ -111,6 +111,8 @@ class Neo4jCheck(PrometheusCheck):
             if "cypher_internal_notification_count" in metric.name:
                 send_monotonic_counter = True
 
+            print('db_name of received metric ' + metric.name + ':' + str(db_name))
+
             tags = []
 
             if db_name: 

--- a/neo4j/datadog_checks/neo4j/neo4j.py
+++ b/neo4j/datadog_checks/neo4j/neo4j.py
@@ -111,7 +111,11 @@ class Neo4jCheck(PrometheusCheck):
             if "cypher_internal_notification_count" in metric.name:
                 send_monotonic_counter = True
 
-            print('db_name of received metric ' + metric.name + ':' + str(db_name))
+
+            try:
+                print('db_name of received metric ' + metric.name + ':' + str(db_name))
+            except:
+                print("An exception occurred for " + metric.name)
 
             tags = []
 

--- a/neo4j/datadog_checks/neo4j/neo4j.py
+++ b/neo4j/datadog_checks/neo4j/neo4j.py
@@ -322,6 +322,7 @@ class Neo4jCheck(PrometheusCheck):
             'ids_in_use_relationship': 'ids_in_use.relationship',
             'ids_in_use_relationship_type': 'ids_in_use.relationship_type',
             'store_size_total': 'store.size.total',
+            'store_size_full': 'store.size.total',
             'store_size_database': 'store.size.database',
             #
             # database transaction log metrics

--- a/neo4j/datadog_checks/neo4j/neo4j.py
+++ b/neo4j/datadog_checks/neo4j/neo4j.py
@@ -92,8 +92,6 @@ class Neo4jCheck(PrometheusCheck):
             send_monotonic_counter = False
             send_buckets = False
 
-            print('received metric ' + metric.name + ' monotonic ' + str(send_monotonic_counter))
-
             if metric.name.startswith("neo4j_dbms_"):
                 db_name = GLOBAL_DB_NAME
                 metric.name = metric.name.replace("neo4j_dbms_", "", 1)
@@ -110,12 +108,6 @@ class Neo4jCheck(PrometheusCheck):
 
             if "cypher_internal_notification_count" in metric.name:
                 send_monotonic_counter = True
-
-
-            try:
-                print('db_name of received metric ' + metric.name + ':' + str(db_name))
-            except:
-                print("An exception occurred for " + metric.name)
 
             tags = []
 

--- a/neo4j/datadog_checks/neo4j/neo4j.py
+++ b/neo4j/datadog_checks/neo4j/neo4j.py
@@ -86,7 +86,7 @@ class Neo4jCheck(PrometheusCheck):
 
     def _check_namespaced_metrics(self, metrics, config, meta_map):
         for metric in metrics:
-            if metric.name == "metadata_info":
+            if metric.name == "metadata_info" or metric.name.startswith("dbms_internal"):
                 continue
 
             send_monotonic_counter = False

--- a/neo4j/datadog_checks/neo4j/neo4j.py
+++ b/neo4j/datadog_checks/neo4j/neo4j.py
@@ -92,6 +92,8 @@ class Neo4jCheck(PrometheusCheck):
             send_monotonic_counter = False
             send_buckets = False
 
+            print('received metric ' + metric.name + ' monotonic ' + str(send_monotonic_counter))
+
             if metric.name.startswith("neo4j_dbms_"):
                 db_name = GLOBAL_DB_NAME
                 metric.name = metric.name.replace("neo4j_dbms_", "", 1)


### PR DESCRIPTION
### What does this PR do?

Repair Datadog integration_extras (Aura incident 1980)

Changes:
*  fix the issue with `dbms_internal_*` metrics that were causing the script to fail completely because of unsupported metric name syntax (still unclear why before upgrading Aura instances to `2025.01` it worked without errors)
* fix the renaming of `neo4j_database_neo4j_store_size_total` to `neo4j_database_neo4j_store_size_full` that happened in `2025.01`

[Trello card](https://trello.com/c/JKXy9HTX/2626-repair-datadog-integrationextras)


### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

